### PR TITLE
Links to comments on Pull Requests aren't valid

### DIFF
--- a/api/controllers/github.rb
+++ b/api/controllers/github.rb
@@ -317,13 +317,18 @@ class Controller < Sinatra::Base
 
     when "pull_request_review_comment"
       summary = Sanitize.clean(payload["comment"]["body"])[0..140]
+      if payload["comment"]["_links"]
+        comment_url = payload["comment"]["_links"]["html"]
+      else
+        comment_url = ''
+      end
       Commit.create({
         type: type,
         repo: repo,
         user: user,
         date: now,
         text: "#{username} commented #{summary}",
-        link: payload["comment"]["url"]
+        link: comment_url
       })
     when "push"
       events = []


### PR DESCRIPTION
When commenting on a line of code in a pull request the link is like `https://api.github.com/repos/ArcGIS/composer/pulls/comments/4577294` - however this returns a JSON with error from github. the link should be something like `https://github.com/ArcGIS/composer/pull/123/files#L0R406`
